### PR TITLE
fix: change parameter type of errorList to List from ArrayList

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/ErrorListDialog.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/ErrorListDialog.java
@@ -21,7 +21,7 @@ public class ErrorListDialog extends DialogFragment {
     private ArrayList<String> errorList;
     private String title;
 
-    public static void showDialog(FragmentManager fragmentManager, String title, ArrayList<String> errorList) {
+    public static void showDialog(FragmentManager fragmentManager, String title, List<String> errorList) {
         Bundle bundle = new Bundle();
         bundle.putString(EXTRA_TITLE, title);
         bundle.putStringArrayList(EXTRA_ERROR_LIST, errorList);


### PR DESCRIPTION
Changed parameter type of the errorList. 

Issue [36](https://github.com/rilling/OpenTracksConcordia/issues/36)