### PR TITLE
fix: Use of IsEmpty() to check whether or not collection is empty

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -854,7 +854,7 @@ public class ChartView extends View {
                 break;
             }
         }
-        if (firstChartValueSeries != null && chartPoints.size() > 0) {
+        if (firstChartValueSeries != null && !chartPoints.isEmpty()) {
             int dx = getX(maxX) - pointer.getIntrinsicWidth() / 2;
             double value = firstChartValueSeries.extractDataFromChartPoint(last);
             int dy = getY(firstChartValueSeries, value) - pointer.getIntrinsicHeight();


### PR DESCRIPTION
Use of IsEmpty() method to check whether or not the collection is empty.

Issue [75](https://github.com/rilling/OpenTracksConcordia/issues/75)