### PR TITLE
Change constructor visibility in SpeedOrPace class

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
@@ -69,7 +69,11 @@ public abstract class GenericStatisticsViewHolder extends StatisticViewHolder<St
 
         private final boolean reportSpeed;
 
-        public SpeedOrPace(boolean reportSpeed) {
+        //Change this constructor's visibility to protected
+//        public SpeedOrPace(boolean reportSpeed) {
+//            this.reportSpeed = reportSpeed;
+//        }
+        protected SpeedOrPace(boolean reportSpeed) {
             this.reportSpeed = reportSpeed;
         }
 


### PR DESCRIPTION
Adjusted the visibility of the constructor in the `SpeedOrPace` abstract inner static class from public to protected. This aligns with best practices for abstract classes and clarifies its intended use.

Ref: Issue regarding the visibility of the constructor in `SpeedOrPace`

# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
4. If the PR is not ready for review, please submit it as a [draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
## PLEASE REMOVE

**Describe the pull request**
A clear and concise description of what the pull request changes/adds.

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
