### PR TITLE
Fix Technical Debt: Eliminate Deprecated setTextAppearance Method Usage

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/ClockViewHolder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/ClockViewHolder.java
@@ -18,7 +18,9 @@ public class ClockViewHolder extends StatisticViewHolder<StatsClockItemBinding> 
     @Override
     public void configureUI(DataField dataField) {
         //TODO Unify with GenericStatisticsViewHolder?
-        getBinding().statsClock.setTextAppearance(getContext(), dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryValue : R.style.TextAppearance_OpenTracks_SecondaryValue);
+        int textAppearanceResId = dataField.isPrimary() ? R.style.TextAppearance_OpenTracks_PrimaryValue : R.style.TextAppearance_OpenTracks_SecondaryValue;
+        getBinding().statsClock.setTextAppearance(textAppearanceResId);
+
     }
 
     @Override


### PR DESCRIPTION
This commit addresses a technical debt issue in the codebase. The usage of the deprecated `setTextAppearance` method to set text appearance on a `TextView` has been replaced with a more up-to-date approach, ensuring compatibility with modern Android versions and adherence to best practices.

# Thanks for your contribution.

**Describe the pull request**
This commit addresses a technical debt issue in the codebase. The usage of the deprecated `setTextAppearance` method to set text appearance on a `TextView` has been replaced with a more up-to-date approach, ensuring compatibility with modern Android versions and adherence to best practices.

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
