### PR TITLE
Added missing @deprecated javadoc tag

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/chart/ChartPoint.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartPoint.java
@@ -21,11 +21,18 @@ public class ChartPoint {
     private Double cadence;
     private Double power;
 
-    @Deprecated
+    /**
+     * This class represents a chart point.
+     *
+     * @deprecated This constructor is deprecated and will be removed in a future version.
+     *             Use an alternative constructor or method to create ChartPoint instances.
+     */
+    @Deprecated(since = "1.0", forRemoval = true)
     @VisibleForTesting
     ChartPoint(double altitude) {
         this.altitude = altitude;
     }
+
 
     public ChartPoint(@NonNull TrackStatistics trackStatistics, @NonNull TrackPoint trackPoint, Speed smoothedSpeed, boolean chartByDistance, UnitSystem unitSystem) {
         if (chartByDistance) {


### PR DESCRIPTION
**Describe the technical debt**
**Technical Debt Description:**
File Location:-OpenTracksConcordia\src\main\java\de\dennisguse\opentracks\chart\ChartPoint.java



The technical debt in the existing codebase was primarily related to the lack of proper deprecation information for the `ChartPoint` constructor. This constructor was not adequately marked as deprecated, which could lead to confusion for developers and make it challenging to manage the codebase as it evolves. The absence of proper deprecation information could result in unintended usage or maintenance challenges in the future.



![WhatsApp Image 2023-10-10 at 21 59 58_85ae6c8a](https://github.com/rilling/OpenTracksConcordia/assets/88206430/3afbe073-3c91-4c48-9c90-e9ccbc03432f)



**Proposed solution**
To address this technical debt, the following changes have been made in this issue:
- The `@Deprecated` annotation has been added to the `ChartPoint` constructor, indicating that it is deprecated and providing information on when it was deprecated (`since`) and its intended removal (`forRemoval`).
- Javadoc comments have been added to the constructor to explain why it is deprecated and to guide developers on using alternative constructors or methods.
![git](https://github.com/rilling/OpenTracksConcordia/assets/88206430/37376c0b-d5f8-48a9-b143-0cdc0c8f02a7)



**Technical information**
 - Device: [e.g. Nexus 7 (2013)]
 - OS: [e.g. LineageOS 15.1]
 - OpenTracks version: [e.g. v3.2.4]
 - OpenTracks commit id (only for nightly builds): 880d8e5
