### PR TITLE
Fix issue #72: handle InterruptedException exeption properly

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/ui/util/ExecutorListViewService.java
+++ b/src/main/java/de/dennisguse/opentracks/ui/util/ExecutorListViewService.java
@@ -41,8 +41,11 @@ public class ExecutorListViewService<T> {
             Future<?> future = executorService.submit(runnable);
             try {
                 future.get();
-            } catch (ExecutionException | InterruptedException e) {
+            } catch (ExecutionException e) {
                 e.printStackTrace();
+            } catch (InterruptedException e) {
+                // Re-interrupt the current thread
+                Thread.currentThread().interrupt();
             }
             postExecute(object);
         }).start();


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses issue #72, by properly handling the `InterruptedException` exception.

**Link to the the issue**
Issue #72: Either re-interrupt the method or rethrow the "InterruptedException" that can be caught

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).