### PR TITLE
feat: Give option to the user to select which metric to show in the n…

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -615,4 +615,6 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             case DISTANCE_METRIC_CHOICE -> notifChoice = "distance";
         }
     }
+
+    // Mock commit to check the build
 }

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -17,9 +17,11 @@
 package de.dennisguse.opentracks;
 
 import android.app.ActivityOptions;
+import android.app.AlertDialog;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.database.Cursor;
 import android.graphics.drawable.AnimatedVectorDrawable;
@@ -82,7 +84,7 @@ import de.dennisguse.opentracks.util.StringUtils;
  * @author Leif Hendrik Wilden
  */
 public class TrackListActivity extends AbstractTrackDeleteActivity implements ConfirmDeleteDialogFragment.ConfirmDeleteCaller {
-
+    public static String notifChoice = "speed";
     private static final String TAG = TrackListActivity.class.getSimpleName();
 
     // The following are set in onCreate
@@ -98,6 +100,14 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
 
     private GpsStatusValue gpsStatusValue = TrackRecordingService.STATUS_GPS_DEFAULT;
     private RecordingStatus recordingStatus = TrackRecordingService.STATUS_DEFAULT;
+
+    private static final String NOTIFICATION_PREFERENCE_KEY = "notification_preference_key";
+
+    // Constants for notification options
+    private static final int SPEED_METRIC_CHOICE = 0;
+    private static final int HEART_RATE_METRIC_CHOICE = 1;
+    private static final int DISTANCE_METRIC_CHOICE = 2;
+    private static final int DEFAULT_CHOICE = SPEED_METRIC_CHOICE;
 
     // Callback when an item is selected in the contextual action mode
     private final ActivityUtils.ContextualActionModeCallback contextualActionModeCallback = new ActivityUtils.ContextualActionModeCallback() {
@@ -244,17 +254,8 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
                 return;
             }
 
-            // Not Recording -> Recording
-            updateGpsMenuItem(false, true);
-            new TrackRecordingServiceConnection((service, connection) -> {
-                Track.Id trackId = service.startNewTrack();
-
-                Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class);
-                newIntent.putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
-                startActivity(newIntent);
-
-                connection.unbind(this);
-            }).startAndBind(this, true);
+            // Show the notification dialog to select type of the metric to show in starting new track
+            showNotificationOptionsDialog();
         });
         viewBinding.trackListFabAction.setOnLongClickListener((view) -> {
             if (!recordingStatus.isRecording()) {
@@ -561,5 +562,57 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
     private void onRecordingStatusChanged(RecordingStatus status) {
         recordingStatus = status;
         setFloatButton();
+    }
+
+    // Add a new method for handling the start recording action
+    private void startRecording() {
+        // Not Recording -> Recording
+        updateGpsMenuItem(false, true);
+        new TrackRecordingServiceConnection((service, connection) -> {
+            Track.Id trackId = service.startNewTrack();
+
+            Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class);
+            newIntent.putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
+            startActivity(newIntent);
+
+            connection.unbind(this);
+        }).startAndBind(this, true);
+    }
+
+    // Function to show the dialog for notification options
+    private void showNotificationOptionsDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(R.string.choose_notification_option)
+                .setItems(R.array.notification_options, (dialog, which) -> {
+                    // Store the user's choice
+                    saveNotificationPreference(which);
+
+                    // Update the notification based on the user's choice
+                    updateNotification();
+
+                    // Start recording after the user has made a choice
+                    startRecording();
+                });
+        builder.create().show();
+    }
+
+    // Function to save the user's notification preference
+    private void saveNotificationPreference(int choice) {
+        SharedPreferences preferences = getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putInt(NOTIFICATION_PREFERENCE_KEY, choice);
+        editor.apply();
+    }
+
+    // Function to update the notification based on user's choice
+    private void updateNotification() {
+        SharedPreferences preferences = getPreferences(Context.MODE_PRIVATE);
+        int userChoice = preferences.getInt(NOTIFICATION_PREFERENCE_KEY, DEFAULT_CHOICE);
+
+        switch (userChoice) {
+            case SPEED_METRIC_CHOICE -> notifChoice = "speed";
+            case HEART_RATE_METRIC_CHOICE -> notifChoice = "heartRate";
+            case DISTANCE_METRIC_CHOICE -> notifChoice = "distance";
+        }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -616,5 +616,6 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
         }
     }
 
-    // Mock commit to check the build
+    // Mock commit to check the
+    // Mock commit part 2
 }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceNotificationManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceNotificationManager.java
@@ -17,6 +17,7 @@ import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.TrackListActivity;
 import de.dennisguse.opentracks.data.models.Distance;
 import de.dennisguse.opentracks.data.models.DistanceFormatter;
+import de.dennisguse.opentracks.data.models.HeartRate;
 import de.dennisguse.opentracks.data.models.SpeedFormatter;
 import de.dennisguse.opentracks.data.models.TrackPoint;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
@@ -93,9 +94,26 @@ class TrackRecordingServiceNotificationManager implements SharedPreferences.OnSh
             previousLocationWasAccurate = currentLocationWasAccurate;
         }
 
-        notificationBuilder.setContentTitle(context.getString(R.string.track_distance_notification, formatter.formatDistance(trackStatistics.getTotalDistance())));
-        String formattedSpeed = SpeedFormatter.Builder().setUnit(unitSystem).setReportSpeedOrPace(true).build(context).formatSpeed(trackPoint.getSpeed());
-        notificationBuilder.setContentText(context.getString(R.string.track_speed_notification, formattedSpeed));
+        switch (TrackListActivity.notifChoice) {
+            case "distance" -> {
+                notificationBuilder.setContentTitle(context.getString(R.string.track_distance_notification, formatter.formatDistance(trackStatistics.getTotalDistance())));
+            }
+            case "speed" -> {
+                String formattedSpeed = SpeedFormatter.Builder().setUnit(unitSystem).setReportSpeedOrPace(true).build(context).formatSpeed(trackPoint.getSpeed());
+                notificationBuilder.setContentTitle(context.getString(R.string.track_speed_notification, formattedSpeed));
+            }
+            case "heartRate" -> {
+                if (trackPoint.hasHeartRate()) {
+                    HeartRate heartRate = trackPoint.getHeartRate();
+                    String formattedHeartRate = String.valueOf(heartRate.getBPM());
+                    notificationBuilder.setContentTitle(context.getString(R.string.track_heart_rate_notification, formattedHeartRate));
+                } else {
+                    // Handle the case where no heart rate data is available
+                    notificationBuilder.setContentTitle(context.getString(R.string.no_heart_rate_data));
+                }
+            }
+        }
+
         notificationBuilder.setSubText(context.getString(R.string.track_recording_notification_accuracy, formattedAccuracy));
         updateNotification();
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -612,6 +612,7 @@ limitations under the License.
     <string name="lap_speed">Lap speed</string>
     <string name="speed">Average moving speed</string>
     <string name="total_distance">Total distance</string>
+    <string name="time_announce">Current time</string>
     <string name="voiceDistanceKilometersPlural">
         {n, plural,
         =1 {1 kilometer}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -497,6 +497,8 @@ limitations under the License.
     <string name="track_recording_notification_accuracy">Location accuracy: %1$s</string>
     <string name="track_distance_notification">Distance: %1$s</string>
     <string name="track_speed_notification">Speed: %1$s</string>
+    <string name="track_heart_rate_notification">Heart Rate: %s BPM</string>
+    <string name="no_heart_rate_data">No heart rate data available</string>
     <string name="track_pace_notification">Pace: %1$s</string>
     <string name="track_markers">%1$s Markers</string>
     <!-- Track Delete -->
@@ -605,7 +607,6 @@ limitations under the License.
     <string name="voice_per_kilometer">per kilometer</string>
     <string name="voice_per_mile">per mile</string>
     <string name="voice_per_nautical_mile">per nautical mile</string>
-    <string name="time_announce">Current time</string>
     <string name="lap_time">Lap time</string>
     <string name="pace">Pace</string>
     <string name="lap_speed">Lap speed</string>
@@ -711,4 +712,12 @@ limitations under the License.
     <string name="always">Always</string>
 
     <string name="introduction_osm_dashboard">OpenTracks itself does not provide a map. Please install OSMDashboard to view your recordings on a map.</string>
+
+    <string-array name="notification_options">
+        <item>Speed</item>
+        <item>Heart Rate</item>
+        <item>Distance</item>
+    </string-array>
+
+    <string name="choose_notification_option">Choose Notification Option</string>
 </resources>


### PR DESCRIPTION
**Describe the pull request**
This pull request introduces a customizable notification feature in OpenTracks, addressing user feedback regarding the lack of pertinent information in the notification area. Users can now personalize the displayed metrics by choosing between speed, heart rate, and distance options before initiating track recording.

**Link to the the issue**
(If available): The link to the issue that this pull request solves. [#177 ](https://github.com/rilling/OpenTracksConcordia/issues/177)

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).
