### PR TITLE
Apply Advanced Filtering #243

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/sensors/driver/BarometerInternal.java
+++ b/src/main/java/de/dennisguse/opentracks/sensors/driver/BarometerInternal.java
@@ -13,6 +13,9 @@ import java.util.concurrent.TimeUnit;
 import de.dennisguse.opentracks.data.models.AtmosphericPressure;
 import de.dennisguse.opentracks.sensors.AltitudeSumManager;
 
+import java.util.LinkedList;
+import java.util.Queue;
+
 public class BarometerInternal {
 
     private static final String TAG = BarometerInternal.class.getSimpleName();
@@ -20,6 +23,9 @@ public class BarometerInternal {
     private static final int SAMPLING_PERIOD = (int) TimeUnit.SECONDS.toMicros(5);
 
     private AltitudeSumManager observer;
+
+    private static final int FILTER_WINDOW_SIZE = 5; // Window size for the moving average filter
+    private Queue<Float> pressureReadings = new LinkedList<>();
 
     private final SensorEventListener listener = new SensorEventListener() {
         @Override
@@ -29,7 +35,22 @@ public class BarometerInternal {
                 return;
             }
 
-            observer.onSensorValueChanged(AtmosphericPressure.ofHPA(event.values[0]));
+            // Add new reading to the queue
+            if (pressureReadings.size() >= FILTER_WINDOW_SIZE) {
+                pressureReadings.poll(); // Remove the oldest reading
+            }
+            pressureReadings.offer(event.values[0]);
+
+            // Calculate the average of the readings in the queue
+            float sum = 0;
+            for (Float reading : pressureReadings) {
+                sum += reading;
+            }
+            float average = sum / pressureReadings.size();
+
+
+            // Use the averaged value instead of the raw reading
+            observer.onSensorValueChanged(AtmosphericPressure.ofHPA(average));
         }
 
         @Override


### PR DESCRIPTION
Implement Moving Average Filter in BarometerInternal

# Thanks for your contribution.

**Describe the pull request**
Implement Moving Average Filter in BarometerInternal

This commit introduces a moving average filter to the BarometerInternal class to smooth out the barometric pressure readings. It helps in reducing the impact of transient fluctuations and outliers in the sensor data, leading to more accurate altitude calculations.

- Added a queue to store a fixed number of recent pressure readings.
- Modified onSensorChanged method to calculate the average of the readings in the queue.
- The averaged pressure value is now used for further processing instead of the raw sensor value.

This change aims to enhance the reliability of altitude measurements, especially in conditions where barometric pressure is prone to rapid changes or anomalies.


**Link to the the issue**
https://github.com/rilling/OpenTracksConcordia/issues/243

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
