### PR TITLE
feat: Option for user to select which metric to be shown in the notification.

### DIFF
--- a/src/androidTest/java/de/dennisguse/opentracks/introduction/IntroductionActivityTest.java
+++ b/src/androidTest/java/de/dennisguse/opentracks/introduction/IntroductionActivityTest.java
@@ -1,0 +1,95 @@
+
+import androidx.test.espresso.DataInteraction;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.filters.LargeTest;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.action.ViewActions.*;
+import static androidx.test.espresso.assertion.ViewAssertions.*;
+import static androidx.test.espresso.matcher.ViewMatchers.*;
+
+import de.dennisguse.opentracks.debug.R;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.is;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class IntroductionActivityTest {
+
+    @Rule
+    public ActivityScenarioRule<IntroductionActivity> mActivityScenarioRule =
+            new ActivityScenarioRule<>(IntroductionActivity.class);
+
+    @Test
+    public void introductionActivityTest() {
+        ViewInteraction floatingActionButton = onView(
+                allOf(withId(R.id.track_list_fab_action), withContentDescription("Record"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(android.R.id.content),
+                                        0),
+                                3),
+                        isDisplayed()));
+        floatingActionButton.perform(click());
+
+        ViewInteraction textView = onView(
+                allOf(withId(android.R.id.text1), withText("Speed"),
+                        withParent(allOf(IsInstanceOf.<View>instanceOf(android.widget.ListView.class),
+                                withParent(IsInstanceOf.<View>instanceOf(android.widget.FrameLayout.class)))),
+                        isDisplayed()));
+        textView.check(matches(withText("Speed")));
+
+        ViewInteraction textView2 = onView(
+                allOf(withId(android.R.id.text1), withText("Heart Rate"),
+                        withParent(allOf(IsInstanceOf.<View>instanceOf(android.widget.ListView.class),
+                                withParent(IsInstanceOf.<View>instanceOf(android.widget.FrameLayout.class)))),
+                        isDisplayed()));
+        textView2.check(matches(withText("Heart Rate")));
+
+        ViewInteraction textView3 = onView(
+                allOf(withId(android.R.id.text1), withText("Distance"),
+                        withParent(allOf(IsInstanceOf.<View>instanceOf(android.widget.ListView.class),
+                                withParent(IsInstanceOf.<View>instanceOf(android.widget.FrameLayout.class)))),
+                        isDisplayed()));
+        textView3.check(matches(withText("Distance")));
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -17,9 +17,11 @@
 package de.dennisguse.opentracks;
 
 import android.app.ActivityOptions;
+import android.app.AlertDialog;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.database.Cursor;
 import android.graphics.drawable.AnimatedVectorDrawable;
@@ -86,7 +88,7 @@ import android.view.MenuItem;
  * @author Leif Hendrik Wilden
  */
 public class TrackListActivity extends AbstractTrackDeleteActivity implements ConfirmDeleteDialogFragment.ConfirmDeleteCaller {
-
+    public static String notifChoice = "speed";
     private static final String TAG = TrackListActivity.class.getSimpleName();
     private CountDownTimer delayTimer;
     private int selectedDelayInSeconds = 0;
@@ -103,6 +105,14 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
 
     private GpsStatusValue gpsStatusValue = TrackRecordingService.STATUS_GPS_DEFAULT;
     private RecordingStatus recordingStatus = TrackRecordingService.STATUS_DEFAULT;
+
+    private static final String NOTIFICATION_PREFERENCE_KEY = "notification_preference_key";
+
+    // Constants for notification options
+    private static final int SPEED_METRIC_CHOICE = 0;
+    private static final int HEART_RATE_METRIC_CHOICE = 1;
+    private static final int DISTANCE_METRIC_CHOICE = 2;
+    private static final int DEFAULT_CHOICE = SPEED_METRIC_CHOICE;
 
     // Callback when an item is selected in the contextual action mode
     private final ActivityUtils.ContextualActionModeCallback contextualActionModeCallback = new ActivityUtils.ContextualActionModeCallback() {
@@ -267,35 +277,8 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
                 return;
             }
 
-            // Not Recording -> Recording
-            try {
-                runOnUiThread(() -> {
-                    for (int i = selectedDelayInSeconds; i >= 0; i--) {
-
-                        final int secondsLeft = i;
-                        Toast toast = Toast.makeText(TrackListActivity.this,"Recording starts in " + secondsLeft + " seconds", Toast.LENGTH_SHORT);
-                        toast.show();
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
-                        toast.cancel();
-                    }});
-
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            updateGpsMenuItem(false, true);
-            new TrackRecordingServiceConnection((service, connection) -> {
-                Track.Id trackId = service.startNewTrack();
-
-                Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class);
-                newIntent.putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
-                startActivity(newIntent);
-
-                connection.unbind(this);
-            }).startAndBind(this, true);
+            // Show the notification dialog to select type of the metric to show in starting new track
+            showNotificationOptionsDialog();
         });
         viewBinding.trackListFabAction.setOnLongClickListener((view) -> {
             if (!recordingStatus.isRecording()) {
@@ -680,5 +663,75 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
     private void onRecordingStatusChanged(RecordingStatus status) {
         recordingStatus = status;
         setFloatButton();
+    }
+
+    // Add a new method for handling the start recording action
+    private void startRecording() {
+        // Not Recording -> Recording
+        try {
+            runOnUiThread(() -> {
+                for (int i = selectedDelayInSeconds; i >= 0; i--) {
+
+                    final int secondsLeft = i;
+                    Toast toast = Toast.makeText(TrackListActivity.this,"Recording starts in " + secondsLeft + " seconds", Toast.LENGTH_SHORT);
+                    toast.show();
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    toast.cancel();
+                }});
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        updateGpsMenuItem(false, true);
+        new TrackRecordingServiceConnection((service, connection) -> {
+            Track.Id trackId = service.startNewTrack();
+
+            Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class);
+            newIntent.putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
+            startActivity(newIntent);
+
+            connection.unbind(this);
+        }).startAndBind(this, true);
+    }
+
+    // Function to show the dialog for notification options
+    private void showNotificationOptionsDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(R.string.choose_notification_option)
+                .setItems(R.array.notification_options, (dialog, which) -> {
+                    // Store the user's choice
+                    saveNotificationPreference(which);
+
+                    // Update the notification based on the user's choice
+                    updateNotification();
+
+                    // Start recording after the user has made a choice
+                    startRecording();
+                });
+        builder.create().show();
+    }
+
+    // Function to save the user's notification preference
+    private void saveNotificationPreference(int choice) {
+        SharedPreferences preferences = getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putInt(NOTIFICATION_PREFERENCE_KEY, choice);
+        editor.apply();
+    }
+
+    // Function to update the notification based on user's choice
+    private void updateNotification() {
+        SharedPreferences preferences = getPreferences(Context.MODE_PRIVATE);
+        int userChoice = preferences.getInt(NOTIFICATION_PREFERENCE_KEY, DEFAULT_CHOICE);
+
+        switch (userChoice) {
+            case SPEED_METRIC_CHOICE -> notifChoice = "speed";
+            case HEART_RATE_METRIC_CHOICE -> notifChoice = "heartRate";
+            case DISTANCE_METRIC_CHOICE -> notifChoice = "distance";
+        }
     }
 }

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceNotificationManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingServiceNotificationManager.java
@@ -17,6 +17,7 @@ import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.TrackListActivity;
 import de.dennisguse.opentracks.data.models.Distance;
 import de.dennisguse.opentracks.data.models.DistanceFormatter;
+import de.dennisguse.opentracks.data.models.HeartRate;
 import de.dennisguse.opentracks.data.models.SpeedFormatter;
 import de.dennisguse.opentracks.data.models.TrackPoint;
 import de.dennisguse.opentracks.settings.PreferencesUtils;
@@ -93,9 +94,26 @@ class TrackRecordingServiceNotificationManager implements SharedPreferences.OnSh
             previousLocationWasAccurate = currentLocationWasAccurate;
         }
 
-        notificationBuilder.setContentTitle(context.getString(R.string.track_distance_notification, formatter.formatDistance(trackStatistics.getTotalDistance())));
-        String formattedSpeed = SpeedFormatter.Builder().setUnit(unitSystem).setReportSpeedOrPace(true).build(context).formatSpeed(trackPoint.getSpeed());
-        notificationBuilder.setContentText(context.getString(R.string.track_speed_notification, formattedSpeed));
+        switch (TrackListActivity.notifChoice) {
+            case "distance" -> {
+                notificationBuilder.setContentTitle(context.getString(R.string.track_distance_notification, formatter.formatDistance(trackStatistics.getTotalDistance())));
+            }
+            case "speed" -> {
+                String formattedSpeed = SpeedFormatter.Builder().setUnit(unitSystem).setReportSpeedOrPace(true).build(context).formatSpeed(trackPoint.getSpeed());
+                notificationBuilder.setContentTitle(context.getString(R.string.track_speed_notification, formattedSpeed));
+            }
+            case "heartRate" -> {
+                if (trackPoint.hasHeartRate()) {
+                    HeartRate heartRate = trackPoint.getHeartRate();
+                    String formattedHeartRate = String.valueOf(heartRate.getBPM());
+                    notificationBuilder.setContentTitle(context.getString(R.string.track_heart_rate_notification, formattedHeartRate));
+                } else {
+                    // Handle the case where no heart rate data is available
+                    notificationBuilder.setContentTitle(context.getString(R.string.no_heart_rate_data));
+                }
+            }
+        }
+
         notificationBuilder.setSubText(context.getString(R.string.track_recording_notification_accuracy, formattedAccuracy));
         updateNotification();
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -526,6 +526,8 @@ limitations under the License.
     <string name="track_recording_notification_accuracy">Location accuracy: %1$s</string>
     <string name="track_distance_notification">Distance: %1$s</string>
     <string name="track_speed_notification">Speed: %1$s</string>
+    <string name="track_heart_rate_notification">Heart Rate: %s BPM</string>
+    <string name="no_heart_rate_data">No heart rate data available</string>
     <string name="track_pace_notification">Pace: %1$s</string>
     <string name="track_markers">%1$s Markers</string>
     <!-- Track Delete -->
@@ -634,7 +636,6 @@ limitations under the License.
     <string name="voice_per_kilometer">per kilometer</string>
     <string name="voice_per_mile">per mile</string>
     <string name="voice_per_nautical_mile">per nautical mile</string>
-    <string name="time_announce">Current time</string>
     <string name="lap_time">Lap time</string>
     <string name="pace">Pace</string>
     <string name="lap_speed">Lap speed</string>
@@ -740,4 +741,11 @@ limitations under the License.
     <string name="always">Always</string>
 
     <string name="introduction_osm_dashboard">OpenTracks itself does not provide a map. Please install OSMDashboard to view your recordings on a map.</string>
+    <string-array name="notification_options">
+        <item>Speed</item>
+        <item>Heart Rate</item>
+        <item>Distance</item>
+    </string-array>
+
+    <string name="choose_notification_option">Choose Notification Option</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -641,6 +641,7 @@ limitations under the License.
     <string name="lap_speed">Lap speed</string>
     <string name="speed">Average moving speed</string>
     <string name="total_distance">Total distance</string>
+    <string name="time_announce">Current time</string>
     <string name="voiceDistanceKilometersPlural">
         {n, plural,
         =1 {1 kilometer}


### PR DESCRIPTION
Describe the pull request
This pull request introduces a customizable notification feature in OpenTracks, addressing user feedback regarding the lack of pertinent information in the notification area. Users can now personalize the displayed metrics by choosing between speed, heart rate, and distance options before initiating track recording.

Link to the the issue
(If available): The link to the issue that this pull request solves. [#177](https://github.com/rilling/OpenTracksConcordia/issues/177)

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
