### PR TITLE
184 delayed tracking start

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -271,19 +271,18 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             try {
                 runOnUiThread(() -> {
                     for (int i = selectedDelayInSeconds; i >= 0; i--) {
+
                         final int secondsLeft = i;
                         Toast toast = Toast.makeText(TrackListActivity.this,"Recording starts in " + secondsLeft + " seconds", Toast.LENGTH_SHORT);
                         toast.show();
-                        Handler handler = new Handler();
-                        handler.postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                toast.cancel();
-                            }
-                        }, 500);
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        toast.cancel();
                     }});
 
-                Thread.sleep(selectedDelayInSeconds * 1000);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -33,7 +33,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.Toast;
-
+import android.os.Handler;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
@@ -269,8 +269,22 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
 
             // Not Recording -> Recording
             try {
-                Thread.sleep(selectedDelayInSeconds*1000);
-            } catch (InterruptedException e) {
+                runOnUiThread(() -> {
+                    for (int i = selectedDelayInSeconds; i >= 0; i--) {
+                        final int secondsLeft = i;
+                        Toast toast = Toast.makeText(TrackListActivity.this,"Recording starts in " + secondsLeft + " seconds", Toast.LENGTH_SHORT);
+                        toast.show();
+                        Handler handler = new Handler();
+                        handler.postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                toast.cancel();
+                            }
+                        }, 500);
+                    }});
+
+                Thread.sleep(selectedDelayInSeconds * 1000);
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
             updateGpsMenuItem(false, true);

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -31,11 +31,13 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.appcompat.widget.PopupMenu;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.cursoradapter.widget.ResourceCursorAdapter;
@@ -180,6 +182,16 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             }
         });
 
+        MaterialButton timerButton = findViewById(R.id.timer_button);
+
+        // Set up click listener for the timer button
+        timerButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Show the dropdown menu
+                showTimerMenu(v);
+            }
+        });
         viewBinding.trackList.setEmptyView(viewBinding.trackListEmptyView);
         viewBinding.trackList.setOnItemClickListener((parent, view, position, trackIdId) -> {
             Track.Id trackId = new Track.Id(trackIdId);
@@ -374,7 +386,48 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
         }
         return super.onKeyUp(keyCode, event);
     }
+    public void showTimerMenu(View view) {
+        PopupMenu popupMenu = new PopupMenu(this, view);
+        popupMenu.getMenuInflater().inflate(R.menu.timer_menu, popupMenu.getMenu());
 
+        popupMenu.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                if (item.getItemId() == R.id.menu_no_timer) {
+                    // Handle 0 seconds
+                    showToast("Timer has been disabled");
+                    return true;
+                }
+                if (item.getItemId() == R.id.menu_1_second) {
+                    // Handle 1-second selection
+                    showToast("1 Second selected");
+                    return true;
+                } else if (item.getItemId() == R.id.menu_2_seconds) {
+                    // Handle 2-seconds selection
+                    showToast("2 Seconds selected");
+                    return true;
+                }
+                else if (item.getItemId() == R.id.menu_5_seconds) {
+                    // Handle 5-seconds selection
+                    showToast("5 Seconds selected");
+                    return true;
+                }
+                else if (item.getItemId() == R.id.menu_10_seconds) {
+                    // Handle 10-seconds selection
+                    showToast("10 Seconds selected");
+                    return true;
+                }else {
+                    return false;
+                }
+            }
+        });
+
+        popupMenu.show();
+    }
+
+    private void showToast(String message) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+    }
     @Override
     public void overridePendingTransition(int enterAnim, int exitAnim) {
         //Disable animations as it is weird going into searchMode; looks okay for SplashScreen.
@@ -444,6 +497,7 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             }
         }
     }
+
 
     /**
      * Handles a context item selection.

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -268,6 +268,11 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             }
 
             // Not Recording -> Recording
+            try {
+                Thread.sleep(selectedDelayInSeconds*1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
             updateGpsMenuItem(false, true);
             new TrackRecordingServiceConnection((service, connection) -> {
                 Track.Id trackId = service.startNewTrack();
@@ -290,6 +295,7 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             trackRecordingServiceConnection.stopRecording(TrackListActivity.this);
             viewBinding.trackListFabAction.setImageResource(R.drawable.ic_baseline_record_24);
             viewBinding.trackListFabAction.setBackgroundTintList(ContextCompat.getColorStateList(this, R.color.red_dark));
+            selectedDelayInSeconds=0;
             return true;
         });
 
@@ -467,41 +473,9 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
             showToast("10 Seconds selected");
         }
 
-        // Handle the delay here (start the tracking after the selected delay)
-        startTrackingWithDelay(selectedDelayInSeconds);
     }
 
-    private void startTrackingWithDelay(int delayInSeconds) {
-        if (delayInSeconds > 0) {
-            delayTimer = new CountDownTimer(delayInSeconds * 1000, 1000) {
-                public void onTick(long millisUntilFinished) {
-                    // Do nothing while counting down
-                }
 
-                public void onFinish() {
-                    // Start tracking after the delay
-                    startTracking();
-                }
-            }.start();
-        } else {
-            // Start tracking immediately if no delay is selected
-            startTracking();
-        }
-    }
-
-    private void startTracking() {
-        // Start tracking logic here
-        updateGpsMenuItem(false, true);
-        new TrackRecordingServiceConnection((service, connection) -> {
-            Track.Id trackId = service.startNewTrack();
-
-            Intent newIntent = IntentUtils.newIntent(TrackListActivity.this, TrackRecordingActivity.class);
-            newIntent.putExtra(TrackRecordingActivity.EXTRA_TRACK_ID, trackId);
-            startActivity(newIntent);
-
-            connection.unbind(this);
-        }).startAndBind(this, true);
-    }
 
     private void showToast(String message) {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show();

--- a/src/main/res/drawable/ic_activity_timer_24dp.xml
+++ b/src/main/res/drawable/ic_activity_timer_24dp.xml
@@ -1,0 +1,24 @@
+<vector android:height="24dp" android:viewportHeight="97"
+    android:viewportWidth="97" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000"
+        android:pathData="M6.5,53.5a40,40 0,1 0,80 0a40,40 0,1 0,-80 0z"
+        android:strokeColor="#000000" android:strokeWidth="6"/>
+    <path android:fillColor="#00000000"
+        android:pathData="M46.5,53.5L46.13,23.6"
+        android:strokeColor="#000000" android:strokeWidth="3"/>
+    <path android:fillColor="#000000"
+        android:pathData="M46.04,16.85L50.65,25.8L46.13,23.6L41.65,25.91Z"
+        android:strokeColor="#000000" android:strokeWidth="3"/>
+    <path android:fillColor="#00000000"
+        android:pathData="M46.5,53L76.4,53"
+        android:strokeColor="#000000" android:strokeWidth="3"/>
+    <path android:fillColor="#000000"
+        android:pathData="M83.15,53L74.15,57.5L76.4,53L74.15,48.5Z"
+        android:strokeColor="#000000" android:strokeWidth="3"/>
+    <path android:fillColor="#000000"
+        android:pathData="M12.59,29.693Q0.59,17.693 8.977,9.307Q17.356,0.927 29.355,12.927Z"
+        android:strokeColor="#000000" android:strokeWidth="1"/>
+    <path android:fillColor="#000000"
+        android:pathData="M62.103,14.822Q73.011,1.822 83.467,10.596Q93.916,19.364 83.008,32.364Z"
+        android:strokeColor="#000000" android:strokeWidth="1"/>
+</vector>

--- a/src/main/res/layout/track_list.xml
+++ b/src/main/res/layout/track_list.xml
@@ -123,6 +123,13 @@ limitations under the License.
             android:layout_height="wrap_content"
             app:icon="@drawable/ic_gps_off_24dp"
             app:iconTint="?attr/colorOnBackground" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/timer_button"
+            style="@style/Widget.Material3.Button.IconButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_activity_timer_24dp"
+            app:iconTint="?attr/colorOnBackground" />
 
     </com.google.android.material.bottomappbar.BottomAppBar>
 

--- a/src/main/res/menu/timer_menu.xml
+++ b/src/main/res/menu/timer_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- res/menu/timer_menu.xml -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_no_timer"
+        android:title="None" />
+    <item
+        android:id="@+id/menu_1_second"
+        android:title="1 Second" />
+    <item
+        android:id="@+id/menu_2_seconds"
+        android:title="2 Seconds" />
+    <item
+        android:id="@+id/menu_5_seconds"
+        android:title="5 Seconds" />
+    <item
+        android:id="@+id/menu_10_seconds"
+        android:title="10 Seconds" />
+</menu>


### PR DESCRIPTION
# Thanks for your contribution.

Description:
Successfully implemented a new feature allowing users to set a delayed start for recording. This update includes:

A dropdown menu for selecting the delay duration (options include 0s, 2s, 5s, 10s).
Integration of backend logic to initiate tracking based on the selected delay time.
A visual timer overlay that counts down the remaining seconds until recording starts.
Ensuring sensor readiness during the countdown period for optimal tracking performance.
This feature enhances user experience by providing better preparation time before recording commences.

**Describe the pull request**
This pull request introduces a delayed start functionality for the recording feature. Key changes include:

Addition of a dropdown menu in the UI for users to select a preferred delay time (options: 0s, 2s, 5s, 10s).
Backend logic update to delay the start of recording according to the selected time.
Implementation of a countdown overlay, providing a visual indication of the time remaining before recording begins.
Enhancement to ensure sensor readiness during the delay period.

**Link to the the issue**
https://github.com/rilling/OpenTracksConcordia/issues/184

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
